### PR TITLE
Fixing import api.v1.views.index position before blueprint statement

### DIFF
--- a/api/v1/views/__init__.py
+++ b/api/v1/views/__init__.py
@@ -1,8 +1,11 @@
 #!/usr/bin/python3
-"""Setting up modules for Blueprint Views"""
-
-
+"""
+init module for Blueprint views
+"""
 from flask import Blueprint
-from api.v1.views.index import *
+
 
 app_views = Blueprint('app_views', __name__, url_prefix='/api/v1')
+
+
+from api.v1.views.index import *


### PR DESCRIPTION
Fixing an error produced by misposition of statement: from api.v1.views.index import * before app_views variable declaration.